### PR TITLE
Pretty print hyperion output

### DIFF
--- a/hyperion.cabal
+++ b/hyperion.cabal
@@ -23,12 +23,14 @@ library
     Hyperion.Internal
     Hyperion.Main
     Hyperion.Measurement
+    Hyperion.PrintReport
     Hyperion.Report
     Hyperion.Run
   other-modules:
     Paths_hyperion
   build-depends:
     aeson >= 0.11,
+    ansi-wl-pprint,
     base >= 4.9 && < 5,
     bytestring >= 0.10,
     containers >= 0.5,

--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -105,7 +105,7 @@ options = do
        First <$> optional
          (Options.switch
             (Options.long "pretty" <>
-             Options.help "Pretty prints the measurements of the benchmark."))
+             Options.help "Pretty prints the measurements on stdout."))
      configMonoidRaw <-
        First <$> optional
          (Options.switch

--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -14,7 +14,7 @@ module Hyperion.Main
 import Control.Applicative
 import Control.Exception (Exception, throwIO)
 import Control.Lens ((&), (.~), (%~), (%@~), (^..), folded, imapped, mapped)
-import Control.Monad (unless)
+import Control.Monad (unless, when)
 import Data.HashMap.Strict (HashMap)
 import Data.List (group, sort)
 import Data.Maybe (fromMaybe)
@@ -26,6 +26,7 @@ import Data.Version (showVersion)
 import Hyperion.Analysis
 import Hyperion.Benchmark
 import Hyperion.Measurement
+import Hyperion.PrintReport
 import Hyperion.Report
 import Hyperion.Run
 import qualified Data.ByteString.Lazy.Char8 as BS
@@ -40,6 +41,7 @@ data Mode = Version | List | Run | Analyze
 data ConfigMonoid = ConfigMonoid
   { configMonoidOutputPath :: First FilePath
   , configMonoidMode :: First Mode
+  , configMonoidPretty :: First Bool
   , configMonoidRaw :: First Bool
   }
 
@@ -49,15 +51,18 @@ instance Monoid ConfigMonoid where
       mempty
       mempty
       mempty
+      mempty
   mappend c1 c2 =
     ConfigMonoid
       (mappend (configMonoidOutputPath c1) (configMonoidOutputPath c2))
       (mappend (configMonoidMode c1) (configMonoidMode c2))
+      (mappend (configMonoidPretty c1) (configMonoidPretty c2))
       (mappend (configMonoidRaw c1) (configMonoidRaw c2))
 
 data Config = Config
   { configOutputPath :: Maybe FilePath
   , configMode :: Mode
+  , configPretty :: Bool
   , configRaw :: Bool
   }
 
@@ -68,6 +73,7 @@ configFromMonoid :: ConfigMonoid -> Config
 configFromMonoid ConfigMonoid{..} = Config
     { configOutputPath = getFirst configMonoidOutputPath
     , configMode = fromFirst Analyze configMonoidMode
+    , configPretty = fromFirst False configMonoidPretty
     , configRaw = fromFirst False configMonoidRaw
     }
 
@@ -95,6 +101,11 @@ options = do
           Options.flag' Run
             (Options.long "no-analyze" <>
              Options.help "Only run the benchmarks"))
+     configMonoidPretty <-
+       First <$> optional
+         (Options.switch
+            (Options.long "pretty" <>
+             Options.help "Pretty prints the measurements of the benchmark."))
      configMonoidRaw <-
        First <$> optional
          (Options.switch
@@ -142,6 +153,7 @@ doAnalyze Config{..} bks = do
         report = results & imapped %@~ analyze & mapped %~ strip
     now <- getCurrentTime
     BS.hPutStrLn h $ JSON.encode $ json now Nothing report
+    when configPretty (printReports report)
     maybe (return ()) (\_ -> IO.hClose h) configOutputPath
 
 defaultMainWith :: ConfigMonoid -> [Benchmark] -> IO ()

--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -6,18 +6,17 @@
 module Hyperion.PrintReport (printReports) where
 
 import Control.Lens (view)
-import Control.Monad (forM_)
 import Data.Text (Text, unpack)
 import Data.HashMap.Strict (elems, HashMap)
 import Hyperion.Report
 import Text.PrettyPrint.ANSI.Leijen
 
-printReport :: Report -> IO ()
-printReport report = do
-    putDoc $ green (bold (text (unpack (view reportBenchName report)))) <> line
+formatReport :: Report -> Doc
+formatReport report =
+           green (bold (text (unpack (view reportBenchName report)))) <> line
            <> (indent 2 $ text ("Bench time: " ++ (show (view reportTimeInNanos report)) ++ "ns"))
            <> line
 
 printReports :: HashMap Text Report -> IO ()
 printReports report = do
-  forM_ (elems report) printReport
+  putDoc $ mconcat $ map formatReport (elems report)

--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -15,10 +15,9 @@ import Text.PrettyPrint.ANSI.Leijen
 printReport :: Report -> IO ()
 printReport report = do
     putDoc $ green (bold (text (unpack (view reportBenchName report)))) <> line
-    putDoc $
-       (indent 2 $ text ("Bench time: " ++ (show (view reportTimeInNanos report)) ++ "ns")) <> line
+           <> (indent 2 $ text ("Bench time: " ++ (show (view reportTimeInNanos report)) ++ "ns"))
+           <> line
 
 printReports :: HashMap Text Report -> IO ()
 printReports report = do
-  _ <- forM_ (elems report) printReport
-  return ()
+  forM_ (elems report) printReport

--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -1,0 +1,24 @@
+{- This module is used for pretty printing the hyperion report.
+ - This is mostly put in a separate module to avoid conflicts in
+ - the imports of (<>) from Monoid an ansi-wl-pprint
+ -}
+
+module Hyperion.PrintReport (printReports) where
+
+import Control.Lens (view)
+import Control.Monad (forM_)
+import Data.Text (Text, unpack)
+import Data.HashMap.Strict (elems, HashMap)
+import Hyperion.Report
+import Text.PrettyPrint.ANSI.Leijen
+
+printReport :: Report -> IO ()
+printReport report = do
+    putDoc $ green (bold (text (unpack (view reportBenchName report)))) <> line
+    putDoc $
+       (indent 2 $ text ("Bench time: " ++ (show (view reportTimeInNanos report)) ++ "ns")) <> line
+
+printReports :: HashMap Text Report -> IO ()
+printReports report = do
+  _ <- forM_ (elems report) printReport
+  return ()

--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -19,4 +19,4 @@ formatReport report =
 
 printReports :: HashMap Text Report -> IO ()
 printReports report = do
-  putDoc $ mconcat $ map formatReport (elems report)
+  putDoc $ foldMap formatReport (elems report)


### PR DESCRIPTION
Tries to answer to #9 

The change in UX, is to have a `--pretty` flag that can be passed to add a human readable output to the command line.