### PR TITLE
Add the example to the .cabal, so that it is build in tests

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -25,4 +25,5 @@ benchmarks =
         [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]
     ]
 
+main :: IO ()
 main = defaultMain benchmarks

--- a/hyperion.cabal
+++ b/hyperion.cabal
@@ -46,6 +46,17 @@ library
     unordered-containers >= 0.2,
     vector >= 0.11
   default-language: Haskell2010
+  ghc-options:         -Wall
+
+executable hyperion-example
+  hs-source-dirs:      examples
+  main-is:             Main.hs
+  build-depends:
+    base,
+    hyperion,
+    process
+  default-language:    Haskell2010
+  ghc-options:         -Wall
 
 test-suite spec
   type:


### PR DESCRIPTION
This allows the example to be built in the test, so that we make sure that it is always valid.