### PR TITLE
WIP - Run benchmarks on multiple batch sizes

### DIFF
--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -139,7 +139,7 @@ doRun bks = do
     -- Better asymptotics than nub.
     unless (length (group (sort nms)) == length nms) $
       throwIO $ DuplicateNames [ n | n:_:_ <- group (sort nms) ]
-    foldMap (runBenchmark (sample 100 (fixed 5))) bks
+    foldMap runBenchmark bks
 
 doAnalyze :: Config -> [Benchmark] -> IO ()
 doAnalyze Config{..} bks = do

--- a/tests/Hyperion/BenchmarkSpec.hs
+++ b/tests/Hyperion/BenchmarkSpec.hs
@@ -52,5 +52,5 @@ spec = do
       it "returns as many samples as there are benchmarks" $ property $ \b ->
         not (hasSeries b) ==>
         monadicIO $ do
-          results <- run $ runBenchmark (fixed 1) b
+          results <- run $ runBenchmarkWithConfig (fixed 1) b
           assert (length results == length (nub (b^..namesOf)))


### PR DESCRIPTION
This currently simply moves the batching logic inside Run.hs

This is mergeable if you want to keep PRs small (works for me).

Next step is to include the logic from https://github.com/bos/criterion/blob/master/Criterion/Measurement.hs#L86-L129 in Run.hs

Works on solving #14