### PR TITLE
Show concise numbers with --pretty

### DIFF
--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -5,6 +5,7 @@
 
 module Hyperion.PrintReport (printReports) where
 
+import Numeric
 import Control.Lens (view)
 import Data.Text (Text, unpack)
 import Data.HashMap.Strict (elems, HashMap)
@@ -14,8 +15,19 @@ import Text.PrettyPrint.ANSI.Leijen
 formatReport :: Report -> Doc
 formatReport report =
            green (bold (text (unpack (view reportBenchName report)))) <> line
-           <> (indent 2 $ text ("Bench time: " ++ (show (view reportTimeInNanos report)) ++ "ns"))
+           <> (indent 2 $ text ("Bench time: " ++ prettyNanos (view reportTimeInNanos report)))
            <> line
+  where
+    show2decs x= showFFloat (Just 2) x ""
+    prettyNanos :: Double -> String
+    prettyNanos x
+      -- seconds
+      | x > 1e9 = show2decs (x/1e9) ++ "s"
+      -- milliseconds
+      | x > 1e6 = show2decs (x/1e6) ++ "ms"
+      -- microseconds
+      | x > 1e3 = show2decs (x/1e3) ++ "us"
+      | otherwise = show2decs x ++ "ns"
 
 printReports :: HashMap Text Report -> IO ()
 printReports report = do


### PR DESCRIPTION
This shows more concise numbers on the pretty printed output. 

`hyperion-example` before:
```
id
  Bench time: 78.52054945054945ns
pure-functions:22/fact
  Bench time: 164.67813186813186ns
pure-functions:22/fib
  Bench time: 93210.96186813187ns
```

`hyperion-example` after:
```
id
  Bench time: 77.82ns
pure-functions:22/fact
  Bench time: 162.90ns
pure-functions:22/fib
  Bench time: 93.38us
```
