### PR TITLE
Custom user data in JSON output

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -14,6 +14,9 @@ fact, fib :: Int -> Int
 fact n = if n == 0 then 1 else n * fact (n - 1)
 fib n = case n of 1 -> 1; 2 -> 1; _ -> fib (n - 1) + fib (n - 2)
 
+choose :: Int -> Int -> Int
+choose n k = fact n `div` (fact k * fact (n - k))
+
 benchmarks :: [Benchmark]
 benchmarks =
     [ bench "id" (nf id ())
@@ -24,6 +27,10 @@ benchmarks =
           ]
     , withSampling (timebounded (repeat 10) fiveSecs) $ bgroup "roundrip"
         [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]
+    , benchMany
+        "n choose k"
+        [(x,y) | x <- [1..4], y <- [1..4], x >= y]
+        (nf $ uncurry choose)
     ]
   where
     fiveSecs = 5 * 1000 * 1000 * 1000 -- in nanoseconds

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -27,7 +27,7 @@ benchmarks =
           ]
     , withSampling (timebounded (repeat 10) fiveSecs) $ bgroup "roundrip"
         [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]
-    , benchMany
+    , benchMany2
         "n choose k"
         [(x,y) | x <- [1..4], y <- [1..4], x >= y]
         (nf $ uncurry choose)

--- a/hyperion.cabal
+++ b/hyperion.cabal
@@ -39,6 +39,7 @@ library
     directory,
     exceptions >= 0.8,
     filepath,
+    hashable >= 1.2.4,
     lens >= 4.0,
     mtl >= 2.2,
     optparse-applicative >= 0.12,

--- a/src/Hyperion/Analysis.hs
+++ b/src/Hyperion/Analysis.hs
@@ -27,13 +27,13 @@ import Hyperion.Report
 
 data Component = BenchC Metadata | GroupC Metadata | SeriesC Metadata
 
-qualName :: [Component] -> Metadata
-qualName = go ""
+qualMeta :: [Component] -> Metadata
+qualMeta = go ""
   where
     go index [BenchC txt] = txt <> index
     go index (GroupC txt : comps) = txt <> index <> "/" <> go "" comps
     go index (SeriesC txt : comps) = go (index <> ":" <> txt) comps
-    go _ _ = error "qualName: Impossible"
+    go _ _ = error "qualMeta: Impossible"
 
 namesOf :: Fold Benchmark Text
 namesOf = metadataOf.benchmarkName
@@ -44,7 +44,7 @@ metadataOf = go []
     go :: [Component] -> Fold Benchmark Metadata
     go comps f (Bench show' toJs _ _ x) =
       let md = Metadata (toJs x) (show' x)
-      in coerce $ f (qualName (comps <> [BenchC md]))
+      in coerce $ f (qualMeta (comps <> [BenchC md]))
     go comps f (Group name bks) =
       let md = mempty { _benchmarkName = name }
       in coerce $ (folded.go (comps <> [GroupC md])) f bks

--- a/src/Hyperion/Analysis.hs
+++ b/src/Hyperion/Analysis.hs
@@ -3,6 +3,7 @@
 
 module Hyperion.Analysis
   ( namesOf
+  , metadataOf
   , analyze
   ) where
 
@@ -24,9 +25,9 @@ import Hyperion.Internal
 import Hyperion.Measurement
 import Hyperion.Report
 
-data Component = BenchC Text | GroupC Text | SeriesC Text
+data Component = BenchC Metadata | GroupC Metadata | SeriesC Metadata
 
-qualName :: [Component] -> Text
+qualName :: [Component] -> Metadata
 qualName = go ""
   where
     go index [BenchC txt] = txt <> index
@@ -35,32 +36,40 @@ qualName = go ""
     go _ _ = error "qualName: Impossible"
 
 namesOf :: Fold Benchmark Text
-namesOf = go []
+namesOf = metadataOf.benchmarkName
+
+metadataOf :: Fold Benchmark Metadata
+metadataOf = go []
   where
-    go :: [Component] -> Fold Benchmark Text
-    go comps f (Bench name _) = coerce $ f (qualName (comps <> [BenchC name]))
-    go comps f (Group name bks) = coerce $ (folded.go (comps <> [GroupC name])) f bks
+    go :: [Component] -> Fold Benchmark Metadata
+    go comps f (Bench show' toJs _ _ x) =
+      let md = Metadata (toJs x) (show' x)
+      in coerce $ f (qualName (comps <> [BenchC md]))
+    go comps f (Group name bks) =
+      let md = mempty { _benchmarkName = name }
+      in coerce $ (folded.go (comps <> [GroupC md])) f bks
     go comps f (Bracket _ _ g) = go comps f (g Empty)
     go comps f (Series xs g) =
       coerce $ for xs $ \x ->
-        go (comps <> [SeriesC (Text.pack (show x))]) f (g Empty)
+        go (comps <> [SeriesC $ mempty {_benchmarkName = Text.pack (show x) }]) f (g Empty)
     go comps f (WithSampling _ bk) = go comps f bk
 
     coerce :: (Contravariant f, Applicative f) => f a -> f b
     coerce = contramap (const ()) . fmap (const ())
 
 analyze
-  :: Text -- ^ Benchmark name.
+  :: Metadata -- ^ Benchmark metadata.
   -> Sample -- ^ Measurements.
   -> Report
-analyze name samp = Report
-    { _reportBenchName = name
+analyze md samp = Report
+    { _reportBenchName = _benchmarkName md
     , _reportTimeInNanos =
         totalDuration / trueNumIterations
     , _reportCycles = Nothing
     , _reportAlloc = Nothing
     , _reportGarbageCollections = Nothing
     , _reportMeasurements = Just samp
+    , _reportUserData = _userData md
     }
   where
     totalDuration =

--- a/src/Hyperion/Benchmark.hs
+++ b/src/Hyperion/Benchmark.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE GADTSyntax #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Hyperion.Benchmark
   ( -- * Benchmarks
     Benchmark(..)
   , bench
   , benchWith
+  , benchMany
   , bgroup
   , env
   , series
@@ -66,6 +68,16 @@ benchWith
   -> (b -> Batch ())
   -> a -> Benchmark
 benchWith = Bench
+
+benchMany
+  :: (Show a, JSON.ToJSON a)
+  => String
+  -> [a]
+  -> (a -> Batch ())
+  -> Benchmark
+benchMany bname xs bnc =
+    bgroup bname $ flip fmap xs $
+      benchWith (Text.pack . show) (\x -> [("data",JSON.toJSON x)]) id bnc
 
 bgroup :: String -> [Benchmark] -> Benchmark
 bgroup name bks = Group (Text.pack name) bks

--- a/src/Hyperion/Benchmark.hs
+++ b/src/Hyperion/Benchmark.hs
@@ -46,7 +46,7 @@ sp = showChar ' '
 
 instance Show Benchmark where
   showsPrec _ (Bench show' _ _ _ x) =
-      showString "Bench" . sp . shows (show' x) . sp . showString "_"
+      showString "Bench" . sp . showString (Text.unpack $ show' x) . sp . showString "_"
   showsPrec x (Group name bks) =
       showString "Group" . sp . shows name . sp . showsPrec x bks
   showsPrec x (Bracket _ _ f) =

--- a/src/Hyperion/Benchmark.hs
+++ b/src/Hyperion/Benchmark.hs
@@ -8,6 +8,7 @@ module Hyperion.Benchmark
   , bench
   , benchWith
   , benchMany
+  , benchMany2
   , bgroup
   , env
   , series
@@ -77,7 +78,19 @@ benchMany
   -> Benchmark
 benchMany bname xs bnc =
     bgroup bname $ flip fmap xs $
-      benchWith (Text.pack . show) (\x -> [("data",JSON.toJSON x)]) id bnc
+      benchWith (Text.pack . show) (\x -> [("x",JSON.toJSON x)]) id bnc
+
+benchMany2
+  :: (Show a, Show b, JSON.ToJSON a, JSON.ToJSON b)
+  => String
+  -> [(a,b)]
+  -> ((a, b) -> Batch ())
+  -> Benchmark
+benchMany2 bname xs bnc =
+    bgroup bname $ flip fmap xs $
+      benchWith (Text.pack . show) toJs id bnc
+  where
+    toJs (x,y) = [("x", JSON.toJSON x), ("y", JSON.toJSON y)]
 
 bgroup :: String -> [Benchmark] -> Benchmark
 bgroup name bks = Group (Text.pack name) bks

--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -138,7 +138,7 @@ instance Show DuplicateNames where
 doList :: [Benchmark] -> IO ()
 doList bks = mapM_ Text.putStrLn $ bks^..folded.namesOf
 
-doRun :: [Benchmark] -> IO (HashMap Text Sample)
+doRun :: [Benchmark] -> IO (HashMap Metadata Sample)
 doRun bks = do
     let nms = bks^..folded.namesOf
     -- Better asymptotics than nub.

--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -10,6 +10,7 @@ import Control.Lens (view)
 import Data.Text (Text, unpack)
 import Data.HashMap.Strict (elems, HashMap)
 import Hyperion.Report
+import Hyperion.Measurement (Metadata)
 import Text.PrettyPrint.ANSI.Leijen
 
 formatReport :: Report -> Doc
@@ -29,6 +30,6 @@ formatReport report =
       | x > 1e3 = show2decs (x/1e3) ++ "us"
       | otherwise = show2decs x ++ "ns"
 
-printReports :: HashMap Text Report -> IO ()
+printReports :: HashMap Metadata Report -> IO ()
 printReports report = do
   putDoc $ foldMap formatReport (elems report)

--- a/src/Hyperion/Report.hs
+++ b/src/Hyperion/Report.hs
@@ -8,6 +8,7 @@ import Control.Lens.TH (makeLenses)
 import Control.Lens (_head, (%~))
 import GHC.Generics (Generic)
 import qualified Data.Aeson as JSON
+import qualified Data.Aeson.Types as JSON
 import Data.Aeson ((.=))
 import Data.Aeson.TH
 import Data.Char (toLower)
@@ -16,9 +17,8 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.Int
 import Data.List (stripPrefix)
 import Data.Maybe (fromJust)
-import Data.Text (Text)
 import Data.Time (UTCTime)
-import Hyperion.Measurement (Sample)
+import Hyperion.Measurement (Sample, Metadata)
 
 data Report = Report
   { _reportBenchName :: !Text
@@ -27,11 +27,12 @@ data Report = Report
   , _reportAlloc :: !(Maybe Int64)
   , _reportGarbageCollections :: !(Maybe Int64)
   , _reportMeasurements :: !(Maybe Sample)
+  , _reportUserData :: [JSON.Pair]
   } deriving (Generic)
 makeLenses ''Report
 deriveJSON defaultOptions{ fieldLabelModifier = (_head %~ toLower) . fromJust . stripPrefix "_report" } ''Report
 
-json :: UTCTime -> Maybe Text -> HashMap Text Report -> JSON.Value
+json :: UTCTime -> Maybe Text -> HashMap Metadata Report -> JSON.Value
 json timestamp hostId report =
     JSON.object
       [ "metadata" .= JSON.object [ "timestamp" .= timestamp, "location" .= hostId ]

--- a/src/Hyperion/Report.hs
+++ b/src/Hyperion/Report.hs
@@ -17,6 +17,7 @@ import qualified Data.HashMap.Strict as HashMap
 import Data.Int
 import Data.List (stripPrefix)
 import Data.Maybe (fromJust)
+import Data.Text (Text)
 import Data.Time (UTCTime)
 import Hyperion.Measurement (Sample, Metadata)
 

--- a/src/Hyperion/Run.hs
+++ b/src/Hyperion/Run.hs
@@ -32,9 +32,8 @@ import Data.List (mapAccumR)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Sequence (ViewL((:<)), viewl)
-import Data.Text (Text)
 import qualified Data.Vector.Unboxed as Unboxed
-import Hyperion.Analysis (namesOf)
+import Hyperion.Analysis (metadataOf)
 import Hyperion.Benchmark
 import Hyperion.Internal
 import Hyperion.Measurement
@@ -54,7 +53,7 @@ instance (Monad m, Monoid a) => Monoid (StateT' s m a) where
 -- | Default way of running benchmarks.
 -- Default is 100 samples, for each batch size from 1 to 20 with a geometric
 -- progression of 1.2.
-runBenchmark :: Benchmark -> IO (HashMap Text Sample)
+runBenchmark :: Benchmark -> IO (HashMap Metadata Sample)
 runBenchmark = runBenchmarkWithConfig (geometricBatches 100 20 1.2)
 
 -- | Runs the benchmarks with the provided config.
@@ -62,13 +61,13 @@ runBenchmark = runBenchmarkWithConfig (geometricBatches 100 20 1.2)
 runBenchmarkWithConfig
   :: (Batch () -> IO Sample) -- ^ Batch and sampling strategy.
   -> Benchmark -- ^ Benchmark to be run.
-  -> IO (HashMap Text Sample)
+  -> IO (HashMap Metadata Sample)
 runBenchmarkWithConfig samplingConf bk0 =
   -- Ignore the names we find. Use fully qualified names accumulated from the
   -- lens defined above. The order is DFS in both cases.
-  evalStateT (unStateT' (go samplingConf bk0)) (foldMapOf namesOf return bk0)
+  evalStateT (unStateT' (go samplingConf bk0)) (foldMapOf metadataOf return bk0)
   where
-    go cfg (Bench _ batch) = HashMap.singleton <$> pop <*> lift (cfg batch)
+    go cfg (Bench _ _ f toBatch x) = HashMap.singleton <$> pop <*> lift (cfg $ toBatch $ f x)
     go cfg (Group _ bks) = foldMap (go cfg) bks
     go cfg (Bracket ini fini g) =
       bracket (lift ini) (lift . fini) (go cfg . g . Resource)
@@ -167,7 +166,7 @@ splitn n gen = snd $ mapAccumR (flip (const split)) gen [1..n]
 reorder :: RandomGen g => g -> (g -> [Benchmark] -> [Benchmark]) -> Benchmark -> Benchmark
 reorder gen0 shuf = go gen0
   where
-    go _ bk@(Bench _ _) = bk
+    go _ bk@Bench{} = bk
     go _ bk@(WithSampling _ _) = bk
     go gen (Group name bks) = Group name (shuf gen (zipWith go (splitn (length bks) gen) bks))
     go gen (Bracket ini fini f) = Bracket ini fini (\x -> go gen (f x))


### PR DESCRIPTION
This changes allow hyperion to output custom user data in the JSON report. This is useful when analysis to be performed on the results needs to know about the parameter(s). Typical use cases:

* Plot the benchmark results of an algorithm (Y axis: time, X axis: input size) to get an idea of the time complexity
* Linear regression on a known linear-time algorithm
* Plot the benchmark results of a multi-parameter function against _one_ of the parameters at a time

It does so by introducing a more general `benchWith` function:

``` haskell
benchWith :: (a -> Text) -> (a -> [JSON.Pair]) -> (a -> b) -> (b -> Batch ()) -> a -> Benchmark
benchWith = Bench
```

This also required modifications to the `Bench` constructor. This provides the user with a (now more general) way of specifying the textual representation of the parameters and provides the user with a (new) way of specifying the JSON representation of the parameters. The textual representation is (still) used when pretty printing the benchmark results; the new JSON representation is included in the JSON report.

Some extra helpers (`benchMany` for single input `x`, `benchMany2` for tuple input `x` and `y`) are provided to get the user started. Here for instance for an `n` choose `k` benchmark

``` haskell
benchMany2 "n choose k" [(x,y) | x <- [1..4], y <- [1..4], x >= y] (nf $ uncurry choose)
```
we get

``` json
{
  "name": "n choose k/(1,1)",
  "md": [ ["x", 1], ["y", 1] ]
}
{
  "name": "n choose k/(2,1)",
  "md": [ ["x", 2], ["y", 1] ]
}
...
{
  "name": "n choose k/(4,4)",
  "md": [ ["x", 4], ["y", 4] ]
}
```
(ran with:

``` sh
stack exec hyperion-example | jq '.results | .[] | {name: .benchName, md: .userData}'
```
)

There are a few things I'm unhappy with:

* I'd like the user's metadata to be top-level entries in the `results`' elements (and not nested under `userData`), or at least to have a way to flatten it. The reason is that it is much, much easier to work with flat JSON objects in tools like elastic search. In order to flatten it we could always prepend some keys with `user_data_` or with `hyperion_` in order to avoid clashes.
* [implementation details] Using the `Metadata` as a key to the `HashMap` feels icky. I don't think it's a problem currently as I want to tackle #22 soon-ish and change the way the benchmark results are stored (ideally by extracting the tree structure from `Benchmark`).
* [implementation details] `IsString` and `Monoid` instances for `Metadata` were used as a workaround in order to modify the existing code as little as possible, but it's actually not as bad as I thought it would be.
* [implementation details] I'm not too happy with the names of the new `benchX` functions.

Generally feedback much appreciated. I'll add some documentation (for the user's sake) when we've settled on the interface, but things should be quite straightforward as they are now.

_EDIT: added example use-case_
