### PR TITLE
Add series data to JSON output

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -14,6 +14,10 @@ fact, fib :: Int -> Int
 fact n = if n == 0 then 1 else n * fact (n - 1)
 fib n = case n of 1 -> 1; 2 -> 1; _ -> fib (n - 1) + fib (n - 2)
 
+-- | Binomial coefficient
+choose :: Int -> Int -> Int
+choose n k = fact n `div` (fact k * fact (n - k))
+
 benchmarks :: [Benchmark]
 benchmarks =
     [ bench "id" (nf id ())
@@ -24,6 +28,9 @@ benchmarks =
           ]
     , withSampling (timebounded (repeat 10) fiveSecs) $ bgroup "roundrip"
         [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]
+    , series [1..4] $ \n ->
+        series [1..n] $ \k ->
+          bench "n choose k" $ nf (uncurry choose) (n, k)
     ]
   where
     fiveSecs = 5 * 1000 * 1000 * 1000 -- in nanoseconds

--- a/hyperion.cabal
+++ b/hyperion.cabal
@@ -39,6 +39,7 @@ library
     directory,
     exceptions >= 0.8,
     filepath,
+    hashable,
     lens >= 4.0,
     mtl >= 2.2,
     optparse-applicative >= 0.12,

--- a/src/Hyperion/Benchmark.hs
+++ b/src/Hyperion/Benchmark.hs
@@ -36,7 +36,7 @@ data Benchmark where
   Bench :: Text -> Batch () -> Benchmark
   Group :: Text -> [Benchmark] -> Benchmark
   Bracket :: NFData r => IO r -> (r -> IO ()) -> (Env r -> Benchmark) -> Benchmark
-  Series :: Show a => Vector a -> (a -> Benchmark) -> Benchmark
+  Series :: (Show a, Enum a) => Vector a -> (a -> Benchmark) -> Benchmark
   WithSampling :: (Batch () -> IO Sample) -> Benchmark -> Benchmark
 
 sp :: ShowS
@@ -60,7 +60,7 @@ bench name batch = Bench (Text.pack name) batch
 bgroup :: String -> [Benchmark] -> Benchmark
 bgroup name bks = Group (Text.pack name) bks
 
-series :: Show a => Vector a -> (a -> Benchmark) -> Benchmark
+series :: (Show a, Enum a) => Vector a -> (a -> Benchmark) -> Benchmark
 series = Series
 
 -- | Set the sampling strategy for the given 'Benchmark'. The sampling strategy

--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -22,6 +22,7 @@ import Data.Monoid
 import Data.Text (pack, Text, unpack)
 import qualified Data.Text.IO as Text
 import Data.Time (getCurrentTime)
+import Data.Typeable (Typeable)
 import Data.Version (showVersion)
 import Hyperion.Analysis
 import Hyperion.Benchmark
@@ -130,9 +131,9 @@ nullOutputPath = "/dev/null"
 defaultConfig :: ConfigMonoid
 defaultConfig = mempty
 
-data DuplicateIdentifiers = DuplicateIdentifiers [BenchmarkId]
-instance Exception DuplicateIdentifiers
-instance Show DuplicateIdentifiers where
+data DuplicateIdentifiers a = DuplicateIdentifiers [a]
+instance (Show a, Typeable a) => Exception (DuplicateIdentifiers a)
+instance Show a => Show (DuplicateIdentifiers a) where
   show (DuplicateIdentifiers ids) = "Duplicate identifiers: " <> show ids
 
 doList :: [Benchmark] -> IO ()

--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -7,8 +7,8 @@ module Hyperion.PrintReport (printReports) where
 
 import Numeric
 import Control.Lens (view)
-import Data.Text (Text, unpack)
-import Data.HashMap.Strict (elems, HashMap)
+import Data.Text (unpack)
+import Data.HashMap.Strict (HashMap)
 import Hyperion.Report
 import Text.PrettyPrint.ANSI.Leijen
 
@@ -29,6 +29,6 @@ formatReport report =
       | x > 1e3 = show2decs (x/1e3) ++ "us"
       | otherwise = show2decs x ++ "ns"
 
-printReports :: HashMap Text Report -> IO ()
+printReports :: HashMap BenchmarkId Report -> IO ()
 printReports report = do
-  putDoc $ foldMap formatReport (elems report)
+  putDoc $ foldMap formatReport report

--- a/src/Hyperion/Report.hs
+++ b/src/Hyperion/Report.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -11,15 +13,54 @@ import qualified Data.Aeson as JSON
 import Data.Aeson ((.=))
 import Data.Aeson.TH
 import Data.Aeson.Types (camelTo2)
+import Data.Function (on)
+import Data.Hashable (Hashable(..))
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Int
+import Data.Monoid
+import qualified Data.Text as Text
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import Hyperion.Measurement (Sample)
 
+data Parameter = forall a. (Show a, Enum a) => Parameter a
+
+data Component
+  = BenchC Text
+  | GroupC Text
+  | SeriesC Parameter
+
+newtype BenchmarkId = BenchmarkId [Component]
+
+instance Eq BenchmarkId where
+  (==) = (==) `on` renderBenchmarkId
+
+instance Ord BenchmarkId where
+  compare = compare `on` renderBenchmarkId
+
+instance Hashable BenchmarkId where
+  hashWithSalt s = hashWithSalt s . renderBenchmarkId
+
+instance Show BenchmarkId where
+  show = Text.unpack . renderBenchmarkId
+
+renderBenchmarkId :: BenchmarkId -> Text
+renderBenchmarkId (BenchmarkId comps0) = go "" comps0
+  where
+    go index [BenchC txt] = txt <> index
+    go index (GroupC txt : comps) = txt <> index <> "/" <> go "" comps
+    go index (SeriesC (Parameter x) : comps) =
+        go (index <> ":" <> Text.pack (show x)) comps
+    go _ _ = error "renderBenchmarkId: Impossible"
+
+benchmarkParameters :: BenchmarkId -> [Parameter]
+benchmarkParameters (BenchmarkId comps) =
+    concatMap (\case SeriesC x -> [x]; _ -> []) comps
+
 data Report = Report
   { _reportBenchName :: !Text
+  , _reportBenchParams :: [Int]
   , _reportTimeInNanos :: !Double
   , _reportCycles :: !(Maybe Double)
   , _reportAlloc :: !(Maybe Int64)
@@ -29,7 +70,7 @@ data Report = Report
 makeLenses ''Report
 deriveJSON defaultOptions{ fieldLabelModifier = camelTo2 '_' . drop (length @[] "_report") } ''Report
 
-json :: UTCTime -> Maybe Text -> HashMap Text Report -> JSON.Value
+json :: UTCTime -> Maybe Text -> HashMap BenchmarkId Report -> JSON.Value
 json timestamp hostId report =
     JSON.object
       [ "metadata" .= JSON.object [ "timestamp" .= timestamp, "location" .= hostId ]

--- a/src/Hyperion/Run.hs
+++ b/src/Hyperion/Run.hs
@@ -34,9 +34,8 @@ import Data.List (mapAccumR)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Sequence (ViewL((:<)), viewl)
-import Data.Text (Text)
 import qualified Data.Vector.Unboxed as Unboxed
-import Hyperion.Analysis (names)
+import Hyperion.Analysis (BenchmarkId, identifiers)
 import Hyperion.Benchmark
 import Hyperion.Internal
 import Hyperion.Measurement
@@ -56,7 +55,7 @@ instance (Monad m, Monoid a) => Monoid (StateT' s m a) where
 -- | Default way of running benchmarks.
 -- Default is 100 samples, for each batch size from 1 to 20 with a geometric
 -- progression of 1.2.
-runBenchmark :: Benchmark -> IO (HashMap Text Sample)
+runBenchmark :: Benchmark -> IO (HashMap BenchmarkId Sample)
 runBenchmark = runBenchmarkWithConfig (geometricBatches 100 20 1.2)
 
 -- | Runs the benchmarks with the provided config.
@@ -64,11 +63,11 @@ runBenchmark = runBenchmarkWithConfig (geometricBatches 100 20 1.2)
 runBenchmarkWithConfig
   :: (Batch () -> IO Sample) -- ^ Batch and sampling strategy.
   -> Benchmark -- ^ Benchmark to be run.
-  -> IO (HashMap Text Sample)
+  -> IO (HashMap BenchmarkId Sample)
 runBenchmarkWithConfig samplingConf bk0 =
-  -- Ignore the names we find. Use fully qualified names accumulated from the
-  -- lens defined above. The order is DFS in both cases.
-  evalStateT (unStateT' (go samplingConf bk0)) (foldMapOf names return bk0)
+  -- Ignore the identifiers we find. Use fully qualified identifiers
+  -- accumulated from the lens defined above. The order is DFS in both cases.
+  evalStateT (unStateT' (go samplingConf bk0)) (foldMapOf identifiers return bk0)
   where
     go cfg (Bench _ batch) = HashMap.singleton <$> pop <*> lift (cfg batch)
     go cfg (Group _ bks) = foldMap (go cfg) bks

--- a/tests/Hyperion/BenchmarkSpec.hs
+++ b/tests/Hyperion/BenchmarkSpec.hs
@@ -5,11 +5,12 @@
 
 module Hyperion.BenchmarkSpec where
 
-import Control.Lens ((^..), foldOf)
+import Control.Lens ((^..), foldOf, to)
 import Data.List (nub)
 import qualified Data.Text as Text
 import Hyperion.Analysis
 import Hyperion.Benchmark
+import Hyperion.Report (renderBenchmarkId)
 import Hyperion.Run
 import Test.Hspec
 import Test.QuickCheck
@@ -44,7 +45,7 @@ instance Arbitrary Benchmark where
     ]
 
 hasSeries :: Benchmark -> Bool
-hasSeries b = Text.any (==':') (foldOf names b)
+hasSeries b = Text.any (==':') (foldOf (identifiers.to renderBenchmarkId) b)
 
 spec :: Spec
 spec = do
@@ -53,4 +54,4 @@ spec = do
         not (hasSeries b) ==>
         monadicIO $ do
           results <- run $ runBenchmarkWithConfig (fixed 1) b
-          assert (length results == length (nub (b^..names)))
+          assert (length results == length (nub (b^..identifiers)))

--- a/tests/Hyperion/MainSpec.hs
+++ b/tests/Hyperion/MainSpec.hs
@@ -12,11 +12,11 @@ import Test.QuickCheck.Monadic (monadicIO, run)
 spec :: Spec
 spec = do
     describe "defaultMain" $ do
-      it "checks for duplicate names" $ property $ \b ->
-        length (b^..names) /= length (group (sort (b^..names))) ==>
+      it "checks for duplicate identifiers" $ property $ \b ->
+        length (b^..identifiers) /= length (group (sort (b^..identifiers))) ==>
         expectFailure $ monadicIO $ run $
           defaultMainWith defaultConfig{configMonoidMode = return Run} "spec" [b]
-      it "Analyzes uniquely named benchmarks" $ property $ \b ->
-        length (b^..names) == length (group (sort (b^..names))) ==>
+      it "Analyzes uniquely identified benchmarks" $ property $ \b ->
+        length (b^..identifiers) == length (group (sort (b^..identifiers))) ==>
         monadicIO $ run $
           defaultMainWith defaultConfig{configMonoidOutputPath = return nullOutputPath} "specs" [b]


### PR DESCRIPTION
This adds an `Enum` constraint to the `Series` constructor, ensuring
that we can represent `Series`' arguments when creating the report.

This allows the user to inspect the report programatically and match
benchmark results against the benchmark input.

Note that this is a breaking change for `series`; however the JSON output changes should be backwards compatible (we only add field).

Example output:

``` json
    {
      "bench_data": [
        2,
        1
      ],
      "cycles": null,
      "measurements": null,
      "garbage_collections": null,
      "time_in_nanos": 103.23967032967033,
      "bench_name": "n choose k:2:1",
      "alloc": null
    }
```

I'm not happy with the `HashMap` keys, but this is something we can change later when tackling #22 . Also the show instance for `Series` is a bit flaky, as it `show`s a `String`. Will submit a fix soon, but opening the PR already for feedback.