### PR TITLE
Remove Env in Series constructor

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -19,8 +19,8 @@ benchmarks =
     [ bench "id" (nf id ())
     , series [10..10] $ \n ->
         bgroup "pure-functions"
-          [ bench "fact" (use n >>= nf fact)
-          , bench "fib" (use n >>= nf fib)
+          [ bench "fact" (nf fact n)
+          , bench "fib" (nf fib n)
           ]
     , withSampling (timebounded (repeat 10) fiveSecs) $ bgroup "roundrip"
         [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]

--- a/src/Hyperion/Analysis.hs
+++ b/src/Hyperion/Analysis.hs
@@ -43,7 +43,7 @@ names = go []
     go comps f (Bracket _ _ g) = go comps f (g Empty)
     go comps f (Series xs g) =
       coerce $ for xs $ \x ->
-        go (comps <> [SeriesC (Text.pack (show x))]) f (g Empty)
+        go (comps <> [SeriesC (Text.pack (show x))]) f (g x)
     go comps f (WithSampling _ bk) = go comps f bk
 
     coerce :: (Contravariant f, Applicative f) => f a -> f b

--- a/src/Hyperion/Benchmark.hs
+++ b/src/Hyperion/Benchmark.hs
@@ -36,7 +36,7 @@ data Benchmark where
   Bench :: Text -> Batch () -> Benchmark
   Group :: Text -> [Benchmark] -> Benchmark
   Bracket :: NFData r => IO r -> (r -> IO ()) -> (Env r -> Benchmark) -> Benchmark
-  Series :: Show a => Vector a -> (Env a -> Benchmark) -> Benchmark
+  Series :: Show a => Vector a -> (a -> Benchmark) -> Benchmark
   WithSampling :: (Batch () -> IO Sample) -> Benchmark -> Benchmark
 
 sp :: ShowS
@@ -50,7 +50,7 @@ instance Show Benchmark where
   showsPrec x (Bracket _ _ f) =
       showString "Bracket" . sp . showString "(\\_ -> " . showsPrec x (f Empty) . showString ")"
   showsPrec x (Series xs f) =
-      showString "Series" . sp . shows xs . sp . showString "(\\_ -> " . showsPrec x (f Empty) . showString ")"
+      showString "Series" . sp . shows xs . sp . showsPrec x (f <$> xs)
   -- we don't show the sampling
   showsPrec x (WithSampling _opt bk) = showsPrec x bk
 
@@ -60,7 +60,7 @@ bench name batch = Bench (Text.pack name) batch
 bgroup :: String -> [Benchmark] -> Benchmark
 bgroup name bks = Group (Text.pack name) bks
 
-series :: Show a => Vector a -> (Env a -> Benchmark) -> Benchmark
+series :: Show a => Vector a -> (a -> Benchmark) -> Benchmark
 series = Series
 
 -- | Set the sampling strategy for the given 'Benchmark'. The sampling strategy

--- a/src/Hyperion/Run.hs
+++ b/src/Hyperion/Run.hs
@@ -74,7 +74,7 @@ runBenchmarkWithConfig samplingConf bk0 =
     go cfg (Group _ bks) = foldMap (go cfg) bks
     go cfg (Bracket ini fini g) =
       bracket (lift (ini >>= evaluate . force)) (lift . fini) (go cfg . g . Resource)
-    go cfg (Series xs g) = foldMap (go cfg . g . Resource) xs
+    go cfg (Series xs g) = foldMap (go cfg . g) xs
     go _cfg (WithSampling cfg bk) = go cfg bk
 
     pop = do


### PR DESCRIPTION
Prior to this change `Series` took an `Env` argument for running the
benchmark, similar to `Bracket`. The `Env` wrapper makes it impossible
for the user to inspect the parameter when building the `Benchmark`; the
reason for this is that we want to be able to list the benchmarks
"purely", without creating the resource. However in `Series` the
benchmark input does not need to be initialized so we can access it
purely.

Note: breaking change. 