### PR TITLE
More flexible sampling strategy for runBenchmark.

### DIFF
--- a/examples/end-to-end-benchmarks.hs
+++ b/examples/end-to-end-benchmarks.hs
@@ -1,0 +1,27 @@
+#!/usr/bin/env stack
+-- stack --no-nix-pure runghc --package hyperion
+
+{-# LANGUAGE OverloadedLists #-}
+
+module Main where
+
+import Hyperion.Benchmark
+import Hyperion.Run
+import Hyperion.Main
+import System.Process (system)
+
+benchmarks :: [Benchmark]
+benchmarks =
+    [ bgroup "roundrip"
+        [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]
+    ]
+  where
+
+main :: IO ()
+main = defaultMainWith config "hyperion-example-end-to-end" benchmarks
+  where
+    config = defaultConfig
+      { configMonoidSamplingStrategy =
+          return $ SamplingStrategy $ timebounded (repeat 10) fiveSecs
+      }
+    fiveSecs = 5 * 1000 * 1000 * 1000 -- in nanoseconds

--- a/examples/micro-benchmarks.hs
+++ b/examples/micro-benchmarks.hs
@@ -1,14 +1,12 @@
 #!/usr/bin/env stack
--- stack --no-nix-pure runghc
+-- stack --no-nix-pure runghc --package hyperion
 
 {-# LANGUAGE OverloadedLists #-}
 
 module Main where
 
 import Hyperion.Benchmark
-import Hyperion.Run
 import Hyperion.Main
-import System.Process (system)
 
 fact, fib :: Int -> Int
 fact n = if n == 0 then 1 else n * fact (n - 1)
@@ -26,14 +24,10 @@ benchmarks =
           [ bench "fact" (nf fact n)
           , bench "fib" (nf fib n)
           ]
-    , withSampling (timebounded (repeat 10) fiveSecs) $ bgroup "roundrip"
-        [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]
     , series [1..4] $ \n ->
         series [1..n] $ \k ->
           bench "n choose k" $ nf (uncurry choose) (n, k)
     ]
-  where
-    fiveSecs = 5 * 1000 * 1000 * 1000 -- in nanoseconds
 
 main :: IO ()
-main = defaultMain "hyperion-example-package" benchmarks
+main = defaultMain "hyperion-example-micro-benchmarks" benchmarks

--- a/hyperion.cabal
+++ b/hyperion.cabal
@@ -53,9 +53,19 @@ library
   default-language: Haskell2010
   ghc-options:         -Wall
 
-executable hyperion-example
+executable hyperion-micro-benchmark-example
   hs-source-dirs:      examples
-  main-is:             Main.hs
+  main-is:             micro-benchmarks.hs
+  build-depends:
+    base,
+    hyperion,
+    process
+  default-language:    Haskell2010
+  ghc-options:         -Wall
+
+executable hyperion-end-to-end-benchmark-example
+  hs-source-dirs:      examples
+  main-is:             end-to-end-benchmarks.hs
   build-depends:
     base,
     hyperion,

--- a/src/Hyperion/Analysis.hs
+++ b/src/Hyperion/Analysis.hs
@@ -34,7 +34,6 @@ identifiers = go []
     go comps f (Series xs g) =
       coerce $ for xs $ \x ->
         go (comps <> [SeriesC (Parameter x)]) f (g x)
-    go comps f (WithSampling _ bk) = go comps f bk
 
     coerce :: (Contravariant f, Applicative f) => f a -> f b
     coerce = contramap (const ()) . fmap (const ())

--- a/src/Hyperion/Run.hs
+++ b/src/Hyperion/Run.hs
@@ -16,9 +16,9 @@ module Hyperion.Run
   , SamplingStrategy(..)
   , fixed
   , sample
-  , geometricBatches
+  , geometric
   , timebounded
-    -- * strategy helpers
+    -- * Strategy helpers
   , geometricSeries
   ) where
 
@@ -128,18 +128,18 @@ timebounded batchSizes maxTime batch = do
 
 -- | Batching strategy, following a geometric progression from 1
 -- to the provided limit, with the given ratio.
-geometricBatches
+geometric
   :: Int64 -- ^ Sample size.
   -> Int64 -- ^ Max batch size.
   -> Double -- ^ Ratio of geometric progression.
   -> SamplingStrategy
-geometricBatches nSamples limit ratio =
+geometric nSamples limit ratio =
     foldMap (\size -> sample nSamples (fixed size)) (geometricSeries ratio limit)
 
 geometricSeries
-    :: Double -- ^ Geometric progress.
-    -> Int64 -- ^ End of the series.
-    -> [Int64]
+  :: Double -- ^ Geometric progress.
+  -> Int64 -- ^ End of the series.
+  -> [Int64]
 geometricSeries ratio limit =
     if ratio > 1
     then


### PR DESCRIPTION
This is ground work for implementing a `--pattern` command-line flag
that restricts execution of benchmarks to the given pattern.