### PR TITLE
Add pattern-based bench filtering

### DIFF
--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -135,7 +135,7 @@ options = do
          (pack <$> Options.strOption
             (Options.long "pattern" <>
              Options.short 'p' <>
-             Options.help "Select only tests that match pattern (infix)"))
+             Options.help "Select only tests that match pattern (prefix)."))
      pure ConfigMonoid{..}
   where
      -- TODO allow setting this from CLI.
@@ -174,7 +174,7 @@ indexedStrategy Config{..} = case configSelectorPattern of
     Nothing -> uniform configSamplingStrategy
     Just patt -> filtered f configSamplingStrategy
       where
-        f = Text.isInfixOf patt . renderBenchmarkId
+        f = Text.isPrefixOf patt . renderBenchmarkId
 
 doRun
   :: (BenchmarkId -> Maybe SamplingStrategy)

--- a/src/Hyperion/Run.hs
+++ b/src/Hyperion/Run.hs
@@ -11,7 +11,6 @@ module Hyperion.Run
   , shuffle
   , reorder
     -- * Sampling strategy selectors
-  , BenchmarkPredicate(..)
   , filtered
   , uniform
     -- * Sampling strategies
@@ -59,10 +58,6 @@ instance (Monad m, Monoid a) => Monoid (StateT' s m a) where
 -- | Sampling strategy.
 newtype SamplingStrategy = SamplingStrategy (Batch () -> IO Sample)
   deriving (Monoid, Show)
-
--- | 'BenchmarkId'-based predicate for benchmark selection.
-newtype BenchmarkPredicate = BenchmarkPredicate
-  { unBenchmarkPredicate :: BenchmarkId -> Bool }
 
 -- | Provided a sampling strategy (which can be keyed on the 'BenchmarkId'),
 -- sample the runtime of all the benchmark cases in the given benchmark tree.
@@ -141,9 +136,12 @@ uniform = const . Just
 
 -- | Sampling strategies that filters the benchmarks based on a predicate: a
 -- benchmark is included iff the predicate is 'True'.
-filtered :: BenchmarkPredicate -> SamplingStrategy -> (BenchmarkId -> Maybe SamplingStrategy)
+filtered
+  :: (BenchmarkId -> Bool)
+  -> SamplingStrategy
+  -> (BenchmarkId -> Maybe SamplingStrategy)
 filtered p ss bid =
-    if unBenchmarkPredicate p bid then Just ss else Nothing
+    if p bid then Just ss else Nothing
 
 -- | Default to 100 samples, for each batch size from 1 to 20 with a geometric
 -- progression of 1.2.

--- a/src/Hyperion/Run.hs
+++ b/src/Hyperion/Run.hs
@@ -11,6 +11,8 @@ module Hyperion.Run
   , shuffle
   , reorder
     -- * Sampling strategy selectors
+  , BenchmarkPredicate(..)
+  , filtered
   , uniform
     -- * Sampling strategies
   , SamplingStrategy(..)
@@ -57,6 +59,10 @@ instance (Monad m, Monoid a) => Monoid (StateT' s m a) where
 -- | Sampling strategy.
 newtype SamplingStrategy = SamplingStrategy (Batch () -> IO Sample)
   deriving (Monoid, Show)
+
+-- | 'BenchmarkId'-based predicate for benchmark selection.
+newtype BenchmarkPredicate = BenchmarkPredicate
+  { unBenchmarkPredicate :: BenchmarkId -> Bool }
 
 -- | Provided a sampling strategy (which can be keyed on the 'BenchmarkId'),
 -- sample the runtime of all the benchmark cases in the given benchmark tree.
@@ -132,6 +138,12 @@ timeBound maxTime batchSizes = SamplingStrategy $ \batch -> do
 -- benchmarks.
 uniform :: SamplingStrategy -> (BenchmarkId -> Maybe SamplingStrategy)
 uniform = const . Just
+
+-- | Sampling strategies that filters the benchmarks based on a predicate: a
+-- benchmark is included iff the predicate is 'True'.
+filtered :: BenchmarkPredicate -> SamplingStrategy -> (BenchmarkId -> Maybe SamplingStrategy)
+filtered p ss bid =
+    if unBenchmarkPredicate p bid then Just ss else Nothing
 
 -- | Default to 100 samples, for each batch size from 1 to 20 with a geometric
 -- progression of 1.2.


### PR DESCRIPTION
Introduces a CLI argument `-p` (`--pattern`) that allows the user to
specify an infix string that must be present in a benchmark name for the
given benchmark to be run. Implemented through a new type
`BenchmarkPredicate :: BenchmarkId -> Bool`.