### PR TITLE
Update CI docker image

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -1,4 +1,4 @@
-box: fpco/stack-build:lts-7.14
+box: fpco/stack-build:lts-9.0
 
 build:
   steps:


### PR DESCRIPTION
Moving to LTS 9.0 broke the CI builds because the wrong GHC version is
used.

_NOTE: CI currently fails, see #32_