### PR TITLE
Fix test build

### DIFF
--- a/tests/Hyperion/BenchmarkSpec.hs
+++ b/tests/Hyperion/BenchmarkSpec.hs
@@ -51,5 +51,5 @@ spec = do
       it "returns as many samples as there are benchmarks" $ property $ \b ->
         not (hasSeries b) ==>
         monadicIO $ do
-          results <- run $ runBenchmarkWithConfig (fixed 1) b
+          results <- run $ runBenchmark (uniform (fixed 1)) b
           assert (length results == length (nub (b^..identifiers)))


### PR DESCRIPTION
Tests were using `runBenchmarkWithConfig` that disappeared in
7b027ece9705ed191f6c6b94992bd868aafa9118 .