### PR TITLE
Don't duplicate report by default

### DIFF
--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -13,10 +14,12 @@ module Hyperion.Main
   ) where
 
 import Control.Applicative
-import Control.Exception (Exception, throwIO)
+import Control.Exception (Exception, throwIO, bracket)
 import Control.Lens ((&), (.~), (%~), (%@~), (^..), folded, imapped, mapped, to)
-import Control.Monad (unless, when, mzero)
+import Control.Monad (unless, mzero, void)
 import Data.HashMap.Strict (HashMap)
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.List (group, sort)
 import Data.Maybe (fromMaybe)
 import Data.Monoid
@@ -46,10 +49,19 @@ import System.FilePath.Posix (hasTrailingPathSeparator)
 data Mode = Version | List | Run | Analyze
   deriving (Eq, Ord, Show)
 
+-- | Specify a particular way of reporting the benchmark results.
+data ReportOutput a = ReportPretty | ReportJson a
+  deriving (Functor, Eq, Ord)
+
+-- | Context information about the benchmark.
+data ContextInfo = ContextInfo
+  { contextPackageName :: Text
+  , contextExecutableName :: Text
+  }
+
 data ConfigMonoid = ConfigMonoid
-  { configMonoidOutputPath :: First FilePath
+  { configMonoidReportOutputs :: [ReportOutput FilePath]
   , configMonoidMode :: First Mode
-  , configMonoidPretty :: First Bool
   , configMonoidRaw :: First Bool
   , configMonoidSamplingStrategy :: First SamplingStrategy
   , configMonoidExtraMetadata :: UserMetadata
@@ -63,20 +75,17 @@ instance Monoid ConfigMonoid where
       mempty
       mempty
       mempty
-      mempty
   mappend c1 c2 =
     ConfigMonoid
-      (mappend (configMonoidOutputPath c1) (configMonoidOutputPath c2))
+      (mappend (configMonoidReportOutputs c1) (configMonoidReportOutputs c2))
       (mappend (configMonoidMode c1) (configMonoidMode c2))
-      (mappend (configMonoidPretty c1) (configMonoidPretty c2))
       (mappend (configMonoidRaw c1) (configMonoidRaw c2))
       (mappend (configMonoidSamplingStrategy c1) (configMonoidSamplingStrategy c2))
       (mappend (configMonoidExtraMetadata c1) (configMonoidExtraMetadata c2))
 
 data Config = Config
-  { configOutputPath :: Maybe FilePath
+  { configReportOutputs :: Set (ReportOutput FilePath)
   , configMode :: Mode
-  , configPretty :: Bool
   , configRaw :: Bool
   , configSamplingStrategy :: SamplingStrategy
   , configExtraMetadata :: UserMetadata
@@ -87,9 +96,11 @@ fromFirst x = fromMaybe x . getFirst
 
 configFromMonoid :: ConfigMonoid -> Config
 configFromMonoid ConfigMonoid{..} = Config
-    { configOutputPath = getFirst configMonoidOutputPath
+    { configReportOutputs =
+        if null configMonoidReportOutputs
+        then Set.singleton ReportPretty
+        else Set.fromList configMonoidReportOutputs
     , configMode = fromFirst Analyze configMonoidMode
-    , configPretty = fromFirst False configMonoidPretty
     , configRaw = fromFirst False configMonoidRaw
     , configSamplingStrategy = fromFirst defaultStrategy configMonoidSamplingStrategy
     , configExtraMetadata = configMonoidExtraMetadata
@@ -97,13 +108,7 @@ configFromMonoid ConfigMonoid{..} = Config
 
 options :: Options.Parser ConfigMonoid
 options = do
-     configMonoidOutputPath <-
-       First <$> optional
-         (Options.strOption
-            (Options.long "output" <>
-             Options.short 'o' <>
-             Options.help "Where to write the benchmarks output. Can be a directory name" <>
-             Options.metavar "PATH"))
+     configMonoidReportOutputs <- many reportOutputParse
      configMonoidMode <-
        First <$> optional
          (Options.flag' Version
@@ -120,11 +125,6 @@ options = do
           Options.flag' Run
             (Options.long "no-analyze" <>
              Options.help "Only run the benchmarks"))
-     configMonoidPretty <-
-       First <$> optional
-         (Options.switch
-            (Options.long "pretty" <>
-             Options.help "Pretty prints the measurements on stdout."))
      configMonoidRaw <-
        First <$> optional
          (Options.switch
@@ -146,6 +146,17 @@ options = do
       case Text.splitOn ":" txt of
         [x,y] -> pure (x,y)
         _ -> mzero
+
+reportOutputParse :: Options.Parser (ReportOutput FilePath)
+reportOutputParse =
+    (ReportPretty <$ Options.flag' ()
+       (Options.long "pretty" <>
+        Options.help "Pretty prints the measurements on stdout.")) <|>
+    (ReportJson <$> Options.strOption
+      (Options.long "json" <>
+       Options.short 'j' <>
+       Options.help "Where to write the json benchmarks output. Can be a directory name" <>
+       Options.metavar "PATH"))
 
 -- | The path to the null output file. This is @"nul"@ on Windows and
 -- @"/dev/null"@ elsewhere.
@@ -176,35 +187,57 @@ doRun strategy bks = do
       throwIO $ DuplicateIdentifiers [ n | n:_:_ <- group (sort ids) ]
     foldMap (runBenchmark (uniform strategy)) bks
 
+-- | Print the report.
+printReport
+  :: ReportOutput IO.Handle
+  -> UserMetadata
+  -> HashMap BenchmarkId Report
+  -> IO ()
+-- XXX: should we print user metadata in pretty mode as well?
+printReport ReportPretty _ report = printReports report
+printReport (ReportJson h) userMd report = do
+    now <- getCurrentTime
+    BS.hPutStrLn h $ JSON.encode $
+      json now Nothing report userMd
+
+-- | Open a 'Handle' for given report (if needed).
+openReportHandle
+  :: ContextInfo
+  -> ReportOutput FilePath -> IO (ReportOutput IO.Handle)
+openReportHandle _ ReportPretty = pure ReportPretty
+openReportHandle cinfo (ReportJson path) = ReportJson <$> do
+    let packageName = unpack $ contextPackageName cinfo
+        executableName = unpack $ contextExecutableName cinfo
+    dirExists <- doesDirectoryExist path
+    if dirExists ||
+       hasTrailingPathSeparator path
+    then do
+      let filename = packageName <.> executableName <.> "json"
+      createDirectoryIfMissing True path -- Creates the directory if needed.
+      IO.openFile (path </> filename) IO.WriteMode
+    else
+      IO.openFile path IO.WriteMode
+
+closeReportHandle :: ReportOutput IO.Handle -> IO ()
+closeReportHandle ReportPretty = return ()
+closeReportHandle (ReportJson h) = IO.hClose h
+
 doAnalyze
   :: Config -- ^ Hyperion config.
-  -> Text -- ^ Package name.
+  -> ContextInfo -- ^ Benchmark context information.
   -> [Benchmark] -- ^ Benchmarks to be run.
   -> IO ()
-doAnalyze Config{..} packageName bks = do
-    executableName <- getProgName -- Name of the executable that launched the benches.
-    h <- case configOutputPath of
-      Nothing -> return IO.stdout
-      Just path -> do
-        dirExists <- doesDirectoryExist path
-        if dirExists ||
-           hasTrailingPathSeparator path
-        then do
-          let filename = (unpack packageName) <.> executableName <.> "json"
-          createDirectoryIfMissing True path -- Creates the directory if needed.
-          IO.openFile (path </> filename) IO.WriteMode
-        else
-          IO.openFile path IO.WriteMode
+doAnalyze Config{..} cinfo bks = do
     results <- doRun configSamplingStrategy bks
     let strip
           | configRaw = id
           | otherwise = reportMeasurements .~ Nothing
         report = results & imapped %@~ analyze & mapped %~ strip
-    now <- getCurrentTime
-    BS.hPutStrLn h $ JSON.encode $
-      json now Nothing report configExtraMetadata
-    when configPretty (printReports report)
-    maybe (return ()) (\_ -> IO.hClose h) configOutputPath
+    void $ bracket
+      (mapM (openReportHandle cinfo)
+        $ Set.toList configReportOutputs)
+      (mapM_ closeReportHandle)
+      (mapM (\h -> printReport h configExtraMetadata report))
 
 defaultMainWith
   :: ConfigMonoid -- ^ Preset Hyperion config.
@@ -212,18 +245,23 @@ defaultMainWith
   -> [Benchmark] -- ^ Benchmarks to be run.
   -> IO ()
 defaultMainWith presetConfig packageName bks = do
+    executableName <- getProgName -- Name of the executable that launched the benches.
     cmdlineConfig <-
       Options.execParser
         (Options.info
           (Options.helper <*> options)
           Options.fullDesc)
     let config = configFromMonoid (cmdlineConfig <> presetConfig)
+        cinfo = ContextInfo
+          { contextPackageName = pack packageName
+          , contextExecutableName = pack executableName
+          }
     case config of
       Config{..} -> case configMode of
         Version -> putStrLn $ "Hyperion " <> showVersion version
         List -> doList bks
         Run -> do _ <- doRun configSamplingStrategy bks; return ()
-        Analyze -> doAnalyze config (pack packageName) bks
+        Analyze -> doAnalyze config cinfo bks
 
 defaultMain
   :: String -- ^ Package name, user provided.

--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -155,7 +155,10 @@ reportOutputParse =
     (ReportJson <$> Options.strOption
       (Options.long "json" <>
        Options.short 'j' <>
-       Options.help "Where to write the json benchmarks output. Can be a directory name" <>
+       Options.help (unwords
+          ["Where to write the json benchmarks output."
+          ,"Can be a file name, a directory name or '-' for stdout."
+          ]) <>
        Options.metavar "PATH"))
 
 -- | The path to the null output file. This is @"nul"@ on Windows and
@@ -205,6 +208,7 @@ openReportHandle
   :: ContextInfo
   -> ReportOutput FilePath -> IO (ReportOutput IO.Handle)
 openReportHandle _ ReportPretty = pure ReportPretty
+openReportHandle _ (ReportJson "-") = pure $ ReportJson IO.stdout
 openReportHandle cinfo (ReportJson path) = ReportJson <$> do
     let packageName = unpack $ contextPackageName cinfo
         executableName = unpack $ contextExecutableName cinfo


### PR DESCRIPTION
Before these changes the default behavior would be to print both a
pretty-printed and a json report, which doesn't make much sense. This
makes the pretty-printing the default.

It introduces a new datatype `ReportOutput` which records what report
format should be printed. This should also make it easier to add new
report formats.

_Note: this breaks compatibility: `--output` is now `--json`._