### PR TITLE
Json flat

### DIFF
--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -9,6 +9,7 @@ module Hyperion.Main
   ( defaultMain
   , Mode(..)
   , ConfigMonoid(..)
+  , ReportOutput(..)
   , nullOutputPath
   , defaultConfig
   , defaultMainWith

--- a/src/Hyperion/Report.hs
+++ b/src/Hyperion/Report.hs
@@ -7,15 +7,19 @@
 module Hyperion.Report where
 
 import Control.Lens.TH (makeLenses)
+import Data.Monoid
 import GHC.Generics (Generic)
 import qualified Data.Aeson as JSON
 import Data.Aeson ((.=))
 import Data.Aeson.TH
 import Data.Aeson.Types (camelTo2)
+import Data.Bifunctor (first)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Int
 import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Vector as V
 import Hyperion.Measurement (Sample)
 import Hyperion.Internal
 
@@ -40,3 +44,20 @@ json md report =
       [ "metadata" .= md
       , "results" .= HashMap.elems report
       ]
+
+jsonFlat
+  :: JSON.Object -- ^ Metadata
+  -> HashMap BenchmarkId Report
+  -- ^ Report to encode
+  -> JSON.Value
+jsonFlat md report = jsonList $ flip fmap (HashMap.elems report) $ \b ->
+    JSON.object $
+      HashMap.toList md <> (flatten $ JSON.toJSON b)
+  where
+    flatten (JSON.Object b) = concatMap splitParams $ HashMap.toList b
+    flatten x = [("result", x)] -- XXX should never happen
+    jsonList = JSON.Array . V.fromList
+    -- flatten the benchmark params
+    splitParams ("bench_params", JSON.Array xs) =
+      fmap (first (mappend "x_" . Text.pack . show)) (zip [(1::Int)..] $ V.toList xs)
+    splitParams x = [x]

--- a/tests/Hyperion/MainSpec.hs
+++ b/tests/Hyperion/MainSpec.hs
@@ -19,4 +19,4 @@ spec = do
       it "Analyzes uniquely identified benchmarks" $ property $ \b ->
         length (b^..identifiers) == length (group (sort (b^..identifiers))) ==>
         monadicIO $ run $
-          defaultMainWith defaultConfig{configMonoidOutputPath = return nullOutputPath} "specs" [b]
+          defaultMainWith defaultConfig{configMonoidReportOutputs = [ReportJson nullOutputPath]} "specs" [b]


### PR DESCRIPTION
This adds `-f` (`--flat`) which outputs the json report in a flat
(denormalized) format. The output is a JSON list where metadata is
repeated for each element. This is an ES-friendly format.

This depends on #33 (although base branch is `master`).