### PR TITLE
Allow user to overwrite metadata

### DIFF
--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -194,10 +194,10 @@ doAnalyze Config{..} packageName bks = do
     let -- TODO Use output of hostname(1) as reasonable default.
         hostId = Nothing :: Maybe Text
         metadata =
-          -- Append user metadata at the end so that the user can rewrite
-          -- @timestamp@, for instance.
-          HashMap.fromList [ "timestamp" JSON..= now, "location" JSON..= hostId ]
-            <> configUserMetadata
+          configUserMetadata
+          -- Prepend user metadata so that the user can rewrite @timestamp@,
+          -- for instance.
+            <> HashMap.fromList [ "timestamp" JSON..= now, "location" JSON..= hostId ]
     BS.hPutStrLn h $ JSON.encode $ json metadata report
     when configPretty (printReports report)
     maybe (return ()) (\_ -> IO.hClose h) configOutputPath


### PR DESCRIPTION
The `Monoid` instance for HashMap merges two maps with a left bias, so
the user metadata has to be the first argument to `mappend`.