### PR TITLE
Avoid Num instance for TimeSpec

### DIFF
--- a/examples/end-to-end-benchmarks.hs
+++ b/examples/end-to-end-benchmarks.hs
@@ -9,10 +9,11 @@ import Hyperion.Benchmark
 import Hyperion.Run
 import Hyperion.Main
 import System.Process (system)
+import qualified System.Clock as Clock
 
 benchmarks :: [Benchmark]
 benchmarks =
-    [ bgroup "roundrip"
+    [ bgroup "roundtrip"
         [ bench "ping" (nfIO (system "ping -c1 8.8.8.8 > /dev/null")) ]
     ]
 
@@ -20,6 +21,8 @@ main :: IO ()
 main = defaultMainWith config "hyperion-example-end-to-end" benchmarks
   where
     config = defaultConfig
-      { configMonoidSamplingStrategy = return $ timeBound (5 * secs) (repeat 10)
+      { configMonoidSamplingStrategy =
+          pure $ timeBound (fromSeconds 5) (repeat 10)
       }
-    secs = 10^(9::Int) * nanos where nanos = 1
+    fromSeconds :: Integer -> Clock.TimeSpec
+    fromSeconds s = Clock.fromNanoSecs (s * (10^(9::Int)))

--- a/hyperion.cabal
+++ b/hyperion.cabal
@@ -71,6 +71,7 @@ executable hyperion-end-to-end-benchmark-example
   main-is:             end-to-end-benchmarks.hs
   build-depends:
     base,
+    clock,
     hyperion,
     process
   default-language:    Haskell2010


### PR DESCRIPTION
The `Num` instance for TimeSpec defaults to nanoseconds, which causes
all kinds of issues.