### PR TITLE
Use an ordered pair list in lieu of HashMap of storing results.

### DIFF
--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -8,8 +8,6 @@ module Hyperion.PrintReport (printReports) where
 import Numeric
 import Control.Lens (view)
 import Data.Text (unpack)
-import Data.HashMap.Strict (HashMap)
-import Hyperion.Internal
 import Hyperion.Report
 import Text.PrettyPrint.ANSI.Leijen
 
@@ -30,6 +28,6 @@ formatReport report =
       | x > 1e3 = show2decs (x/1e3) ++ "us"
       | otherwise = show2decs x ++ "ns"
 
-printReports :: HashMap BenchmarkId Report -> IO ()
+printReports :: [Report] -> IO ()
 printReports report = do
   putDoc $ foldMap formatReport report

--- a/src/Hyperion/Report.hs
+++ b/src/Hyperion/Report.hs
@@ -14,14 +14,12 @@ import Data.Aeson ((.=))
 import Data.Aeson.TH
 import Data.Aeson.Types (camelTo2)
 import Data.Bifunctor (first)
-import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Int
 import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Vector as V
 import Hyperion.Measurement (Sample)
-import Hyperion.Internal
 
 data Report = Report
   { _reportBenchName :: !Text
@@ -37,20 +35,20 @@ deriveJSON defaultOptions{ fieldLabelModifier = camelTo2 '_' . drop (length @[] 
 
 json
   :: JSON.Object -- ^ Metadata
-  -> HashMap BenchmarkId Report -- ^ Report to encode
+  -> [Report] -- ^ Report to encode
   -> JSON.Value
-json md report =
+json md reports =
     JSON.object
       [ "metadata" .= md
-      , "results" .= HashMap.elems report
+      , "results" .= reports
       ]
 
 jsonFlat
   :: JSON.Object -- ^ Metadata
-  -> HashMap BenchmarkId Report
+  -> [Report]
   -- ^ Report to encode
   -> JSON.Value
-jsonFlat md report = jsonList $ (`map` HashMap.elems report) $ \b ->
+jsonFlat md reports = jsonList $ (`map` reports) $ \b ->
     JSON.object $
       HashMap.toList md <> (flatten $ JSON.toJSON b)
   where

--- a/tests/Hyperion/BenchmarkSpec.hs
+++ b/tests/Hyperion/BenchmarkSpec.hs
@@ -6,7 +6,6 @@
 module Hyperion.BenchmarkSpec where
 
 import Control.Lens ((^..), foldOf, to)
-import Data.List (nub)
 import Hyperion.Analysis
 import Hyperion.Benchmark
 import Hyperion.Run
@@ -52,4 +51,4 @@ spec = do
         not (hasSeries b) ==>
         monadicIO $ do
           results <- run $ runBenchmark (uniform (fixed 1)) b
-          assert (length results == length (nub (b^..identifiers)))
+          assert (length results == length (b^..identifiers))


### PR DESCRIPTION
We weren't needing the better asymptotics of HashMap anyways, and pair
lists at least preserve order.

Fixes #22.