### PR TITLE
Make doAnalyze more user-friendly

### DIFF
--- a/examples/end-to-end-benchmarks.hs
+++ b/examples/end-to-end-benchmarks.hs
@@ -20,7 +20,7 @@ benchmarks =
 main :: IO ()
 main = defaultMainWith config "hyperion-example-end-to-end" benchmarks
   where
-    config = defaultConfig
+    config = defaultConfigMonoid
       { configMonoidSamplingStrategy =
           pure $ timeBound (fromSeconds 5) (repeat 10)
       }

--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -8,11 +8,16 @@
 module Hyperion.Main
   ( defaultMain
   , Mode(..)
+  , Config(..)
   , ConfigMonoid(..)
   , ReportOutput(..)
+  , configFromMonoid
   , nullOutputPath
   , defaultConfig
+  , defaultConfigMonoid
   , defaultMainWith
+  , doAnalyze
+  , doRun
   ) where
 
 import Control.Applicative
@@ -178,8 +183,11 @@ nullOutputPath = "nul"
 nullOutputPath = "/dev/null"
 #endif
 
-defaultConfig :: ConfigMonoid
-defaultConfig = mempty
+defaultConfigMonoid :: ConfigMonoid
+defaultConfigMonoid = mempty
+
+defaultConfig :: Config
+defaultConfig = configFromMonoid defaultConfigMonoid
 
 data DuplicateIdentifiers a = DuplicateIdentifiers [a]
 instance (Show a, Typeable a) => Exception (DuplicateIdentifiers a)
@@ -315,4 +323,4 @@ defaultMain
   :: String -- ^ Package name, user provided.
   -> [Benchmark] -- ^ Benchmarks to be run.
   -> IO ()
-defaultMain = defaultMainWith defaultConfig
+defaultMain = defaultMainWith defaultConfigMonoid

--- a/src/Hyperion/Main.hs
+++ b/src/Hyperion/Main.hs
@@ -267,13 +267,11 @@ doAnalyze Config{..} cinfo bks = do
           | otherwise = reportMeasurements .~ Nothing
         report = results & imapped %@~ analyze & mapped %~ strip
     now <- getCurrentTime
-    let -- TODO Use output of hostname(1) as reasonable default.
-        hostId = Nothing :: Maybe Text
-        metadata =
+    let metadata =
           configUserMetadata
           -- Prepend user metadata so that the user can rewrite @timestamp@,
           -- for instance.
-            <> HashMap.fromList [ "timestamp" JSON..= now, "location" JSON..= hostId ]
+            <> HashMap.fromList [ "timestamp" JSON..= now ]
     void $ bracket
       (mapM (openReportHandle cinfo)
         $ Set.toList configReportOutputs)

--- a/tests/Hyperion/MainSpec.hs
+++ b/tests/Hyperion/MainSpec.hs
@@ -15,8 +15,10 @@ spec = do
       it "checks for duplicate identifiers" $ property $ \b ->
         length (b^..identifiers) /= length (group (sort (b^..identifiers))) ==>
         expectFailure $ monadicIO $ run $
-          defaultMainWith defaultConfig{configMonoidMode = return Run} "spec" [b]
+          defaultMainWith
+            defaultConfigMonoid{configMonoidMode = return Run} "spec" [b]
       it "Analyzes uniquely identified benchmarks" $ property $ \b ->
         length (b^..identifiers) == length (group (sort (b^..identifiers))) ==>
         monadicIO $ run $
-          defaultMainWith defaultConfig{configMonoidReportOutputs = [ReportJson nullOutputPath]} "specs" [b]
+          defaultMainWith
+            defaultConfigMonoid{configMonoidReportOutputs = [ReportJson nullOutputPath]} "specs" [b]


### PR DESCRIPTION
See the commit messages:

```
Remove location from metadata  …
The current location metadata is always null. The user may set an actual
location on the command line.
```

```
Split analysis from analysis reporting  …
This allows users of the library to call `doAnalyze` and work on the
results, rather than having to re-implement it.
```