### PR TITLE
Added linear regression to compute execution time

### DIFF
--- a/src/Hyperion/Analysis.hs
+++ b/src/Hyperion/Analysis.hs
@@ -70,7 +70,7 @@ analyze ident samp = Report
         Sum
         (foldMapOf (measurements.each.batchSize.to realToFrac))
         samp
-    ([slope,yIntercept],determinationCoefficient) = (\(v,r) -> (UV.toList v,r)) $ olsRegress [batchSizesVect] durationsVect 
+    ([slope,yIntercept],determinationCoefficient) = over _1 UV.toList $ olsRegress [batchSizesVect] durationsVect 
       where
         batchSizesVect = UV.fromList $ fromIntegral <$> toListOf (measurements.each.batchSize) samp
         durationsVect = UV.fromList $ fromIntegral <$> toListOf (measurements.each.duration) samp

--- a/src/Hyperion/PrintReport.hs
+++ b/src/Hyperion/PrintReport.hs
@@ -14,7 +14,11 @@ import Text.PrettyPrint.ANSI.Leijen
 formatReport :: Report -> Doc
 formatReport report =
            green (bold (text (unpack (view reportBenchName report)))) <> line
-           <> (indent 2 $ text ("Bench time: " ++ prettyNanos (view reportTimeInNanos report)))
+           <> (indent 2 $ text ("Bench time: " ++ prettyNanos (view reportTimeInNanos report))) <> line
+           <> (indent 2 $ text ("Computed with linear regression: ")) <> line
+           <> (indent 4 $ text ("Bench time: " ++ prettyNanos (view linearRegressionTime report))) <> line
+           <> (indent 4 $ text ("Constant factor: " ++ prettyNanos (view linearRegressionConstant report))) <> line
+           <> (indent 4 $ text ("Confidence: " ++ showFFloat (Just 4) (view linearRegressionConfidence report) ""))
            <> line
   where
     show2decs x= showFFloat (Just 2) x ""

--- a/src/Hyperion/Report.hs
+++ b/src/Hyperion/Report.hs
@@ -25,6 +25,9 @@ data Report = Report
   { _reportBenchName :: !Text
   , _reportBenchParams :: [Int]
   , _reportTimeInNanos :: !Double
+  , _linearRegressionTime :: !Double
+  , _linearRegressionConstant :: !Double
+  , _linearRegressionConfidence :: !Double
   , _reportCycles :: !(Maybe Double)
   , _reportAlloc :: !(Maybe Int64)
   , _reportGarbageCollections :: !(Maybe Int64)


### PR DESCRIPTION
Uses olsRegress from Statistics.Regression, and adds additional information to the reports  and their display. Results on the micro benchmark are strange : some batches have almost perfect confidence, some others are disastrous.

Should be a step in fixing issue #40 